### PR TITLE
Better buttons

### DIFF
--- a/profiles/assets/scss/_variables.scss
+++ b/profiles/assets/scss/_variables.scss
@@ -1,10 +1,9 @@
 // colours (using 'color' because of CSS conventions)
 
 $color-blue-dark: #284162;
-$color-blue-light: #335075;
-$color-banner-blue: #4b98b2;
-$color-banner-blue-light: #dff8fd;
-$color-blue-solid: #0078fb;
+$color-blue-medium: #335075;
+$color-blue-button: #035b99;
+$color-blue-link: #0078fb;
 $color-yellow: #ffbf47;
 $color-white: #ffffff;
 $color-black: #000000;

--- a/profiles/assets/scss/components/_buttons.scss
+++ b/profiles/assets/scss/components/_buttons.scss
@@ -5,10 +5,10 @@
   display: inline-block;
   position: relative;
   margin-top: 10px;
-  padding: 9px 12px;
-  border-radius: 0;
+  padding: 9px 18px;
+  border-radius: 5px;
   color: $color-white;
-  background-color: $color-blue-light;
+  background-color: $color-blue-button;
   border: 2px solid transparent;
   box-shadow: 0 2px 0 black;
   text-align: center;
@@ -54,26 +54,8 @@
 main form button {
   @extend %button-styles;
   font-family: "Noto Sans", sans-serif;
-  width: 100%;
 }
 
 a[role="button"] {
   @extend %button-styles;
-
-  &.full-width {
-    display: inline-block;
-    width: 100%;
-  }
-
-  &.transparent {
-    color: $color-blue-dark;
-    background-color: transparent;
-    border-color: transparent;
-    text-decoration: underline;
-    box-shadow: none;
-  }
-}
-
-.noa-btn {
-  margin-bottom: $space-lg;
 }

--- a/profiles/assets/scss/components/_buttons.scss
+++ b/profiles/assets/scss/components/_buttons.scss
@@ -1,0 +1,79 @@
+%button-styles {
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.1875;
+  display: inline-block;
+  position: relative;
+  margin-top: 10px;
+  padding: 9px 12px;
+  border-radius: 0;
+  color: $color-white;
+  background-color: $color-blue-light;
+  border: 2px solid transparent;
+  box-shadow: 0 2px 0 black;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  text-decoration: none;
+  -webkit-appearance: none;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    bottom: -4px;
+    left: -2px;
+    background: transparent;
+  }
+
+  &:focus {
+    @include focus();
+  }
+
+  &:hover,
+  &:focus {
+    background-color: $color-blue-dark;
+  }
+
+  &:active {
+    top: 2px;
+    box-shadow: none;
+
+    &::before {
+      top: -4px;
+    }
+  }
+}
+
+.start-button {
+  margin: $space-lg 0 $space-xxl 0;
+}
+
+main form button {
+  @extend %button-styles;
+  font-family: "Noto Sans", sans-serif;
+  width: 100%;
+}
+
+a[role="button"] {
+  @extend %button-styles;
+
+  &.full-width {
+    display: inline-block;
+    width: 100%;
+  }
+
+  &.transparent {
+    color: $color-blue-dark;
+    background-color: transparent;
+    border-color: transparent;
+    text-decoration: underline;
+    box-shadow: none;
+  }
+}
+
+.noa-btn {
+  margin-bottom: $space-lg;
+}

--- a/profiles/assets/scss/components/_footer.scss
+++ b/profiles/assets/scss/components/_footer.scss
@@ -23,8 +23,8 @@ footer {
       margin-right: $space-sm;
 
       &::before {
-        content: '\2022';
-        color: $color-blue-light;
+        content: "\2022";
+        color: $color-blue-medium;
         display: inline-block;
         // bullets are about 5px, so add space to compensate
         width: calc(#{$space-sm} + 5px);

--- a/profiles/assets/scss/styles.scss
+++ b/profiles/assets/scss/styles.scss
@@ -6,6 +6,7 @@
 @import "./_base";
 
 /* Partials */
+@import "./components/_buttons";
 @import "./components/_footer";
 @import "./components/_header";
 @import "./components/_nav";

--- a/profiles/templates/profiles/start.html
+++ b/profiles/templates/profiles/start.html
@@ -16,5 +16,5 @@
     <li>{% trans "Has the StopCOVID app installed on their phone" %}</li>
   </ol>
 
-  <p><a href="{% url 'code' %}">{% trans "Generate code" %}</a></p>
+  <div><a href="{% url 'code' %}" role='button' draggable='false'>{% trans "Generate code" %}</a></div>
 {% endblock %}


### PR DESCRIPTION
Brought in most of the code from the CRA codebase. 

They were pretty close to our preferred designs already. Just tweaked a few small things.

## Screenshot 

| before | after |
|--------|-------|
|  <img width="948" alt="Screen Shot 2020-06-24 at 11 58 28 AM" src="https://user-images.githubusercontent.com/2454380/85590274-43b7b180-b612-11ea-9cc2-6daef2aece3b.png">  |  <img width="948" alt="Screen Shot 2020-06-24 at 11 58 21 AM" src="https://user-images.githubusercontent.com/2454380/85590289-461a0b80-b612-11ea-8c22-4b427c776a59.png"> |

Designs look like this 👇

<img width="747" alt="Screen Shot 2020-06-24 at 11 59 41 AM" src="https://user-images.githubusercontent.com/2454380/85590270-42868480-b612-11ea-9b23-c75e7ccc6104.png">
