### PR TITLE
Install gettext for translations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@
 # Pull base image
 FROM python:3.8
 
+# Installs gettext utilities required to makemessages and compilemessages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		gettext \
+	&& rm -rf /var/lib/apt/lists/*
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Install the gettext linux utility required to run the `makemessages` and `compilemessages` django command. 