### PR TITLE
Refactor SignupForm and SignupView

### DIFF
--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -2,6 +2,7 @@ from django.contrib.auth.forms import (
     UserChangeForm,
     AuthenticationForm,
     PasswordResetForm,
+    UserCreationForm,
 )
 from django import forms
 from django.core.exceptions import ValidationError
@@ -56,22 +57,20 @@ class HealthcarePasswordResetForm(HealthcareBaseForm, PasswordResetForm):
         self.fields["email"].label = _("Email address")
 
 
-# TODO: Potentially refactor to extend UserCreationForm
-class SignupForm(HealthcareBaseForm):
-    """A form for creating new users. Includes all the required
-    fields, plus a repeated password."""
+class SignupForm(HealthcareBaseForm, UserCreationForm):
+    """A form for creating new users. Extends from UserCreation form, which
+    means it includes a repeated password."""
 
-    email = forms.EmailField(label=_("Email address"), disabled=True)
     name = forms.CharField(label=_("Full name"), validators=[MaxLengthValidator(200)])
-    password1 = forms.CharField(
-        label=_("Password"),
-        widget=forms.PasswordInput,
-        help_text=_("At least 12 characters"),
-    )
-    password2 = forms.CharField(label=_("Confirm password"), widget=forms.PasswordInput)
 
-    def clean(self):
-        self.cleaned_data = super().clean()
+    class Meta:
+        model = HealthcareUser
+        fields = ("email", "name")
+        widgets = {
+            "email": forms.EmailInput(attrs={"readonly": "readonly"}),
+        }
+
+    def clean_email(self):
         email = self.cleaned_data.get("email", "").lower()
         email_exists = HealthcareUser.objects.filter(email=email)
         if email_exists.count():
@@ -79,31 +78,7 @@ class SignupForm(HealthcareBaseForm):
         if not Invitation.objects.filter(email__iexact=email):
             raise ValidationError(_("An invitation hasn't been sent to this address"))
 
-        self.cleaned_data["email"] = email
-        return self.cleaned_data
-
-    def clean_name(self):
-        name = self.cleaned_data["name"]
-        if len(name) > 200:
-            raise ValidationError(_("Name is too long"))
-        return name
-
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-
-        if password1 and password2 and password1 != password2:
-            raise ValidationError(_("Passwords don't match"))
-
-        return password2
-
-    def save(self, commit=True):
-        user = HealthcareUser.objects.create_user(
-            self.cleaned_data["email"],
-            self.cleaned_data["name"],
-            self.cleaned_data["password1"],
-        )
-        return user
+        return email
 
 
 class HealthcareUserEditForm(UserChangeForm):

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         login_required(TemplateView.as_view(template_name="profiles/start.html")),
         name="start",
     ),
-    re_path(r"signup/$", views.signup, name="signup"),
+    re_path(r"signup/$", views.SignUpView.as_view(), name="signup"),
     # Removed for now
     # path('profiles/', views.UserListView.as_view(), name='profiles'),
     # url(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -3,31 +3,28 @@ import os
 import sys
 
 
-from django.shortcuts import render, redirect
+from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.views.generic import FormView
 
 from django.utils import timezone
 from .forms import SignupForm
 from django.contrib import messages
+from django.urls import reverse_lazy
 
 
-def signup(request):
-    if request.method == "POST":
-        f = SignupForm(
-            request.POST,
-            initial={"email": request.session.get("account_verified_email", None)},
-        )
-        if f.is_valid():
-            f.save()
-            messages.success(request, "Account created successfully")
-            return redirect("start")
+class SignUpView(FormView):
+    form_class = SignupForm
+    template_name = "profiles/signup.html"
+    success_url = reverse_lazy("start")
 
-    else:
-        prepopulate = {}
-        prepopulate["email"] = request.session.get("account_verified_email", None)
-        f = SignupForm(initial=prepopulate)
+    def get_initial(self):
+        return {"email": self.request.session.get("account_verified_email", None)}
 
-    return render(request, "profiles/signup.html", {"form": f})
+    def form_valid(self, form):
+        form.save()
+        messages.success(self.request, "Account created successfully")
+        return super(SignUpView, self).form_valid(form)
 
 
 @login_required


### PR DESCRIPTION
This PR redoes the SignupForm to extend from the `UserCreationForm` and it uses a class-based view for the signup route. We don't have to merge this as-is (the code is already working without this), although I would push for the form refactor to go in because it removes a lot of password-based complexity that we don't have to think about.

Also, I found this really good blog post on `FormView`, which the difference between the functional view and the class view: https://www.agiliq.com/blog/2019/01/django-formview/

### Signup form

As I mentioned in another PR, the [`UserCreationForm`](https://github.com/django/django/blob/ec5aa2161d8015a3fe57dcbbfe14200cd18f0a16/django/contrib/auth/forms.py#L82) has a lot of password management code already in it, so there was a lot of copied and pasted code in our Form. Saving the user and checking the passwords happens in the UserCreationForm, so what we need to do is:

- Add the Validator to the `name` field
- Make sure `email` is 'readonly'
- `clean` the email by making sure it's one of the invited users

 ### Signup view as a class

The `SignupView` extends from `FormView`, so it handles most of the form stuff (ie, the 'get' and 'post' boilerplate, and form validation). We have to set the initial email value and then in `form_valid`, we save the user and return a success message.

