### PR TITLE
Minor CSS fixes to form validation + nav links in header

### DIFF
--- a/profiles/static/scss/components/_header.scss
+++ b/profiles/static/scss/components/_header.scss
@@ -6,15 +6,25 @@ header {
   }
 
   .fip-container {
-    flex-direction: row;
+    flex-direction: column;
     justify-content: space-between;
     display: flex;
     margin-bottom: $space-md;
+
+    @include sm {
+      flex-direction: row;
+      align-items: center;
+    }
 
     li {
       a,
       button {
         padding: 0 $space-xxs;
+        margin-left: -5px;
+
+        @include sm {
+          margin: 0;
+        }
       }
     }
 
@@ -31,9 +41,13 @@ header {
   .canada-flag {
     height: auto;
     max-height: 40px;
-    width: 272px;
+    width: 252px;
     margin-bottom: $space-sm;
     margin-right: $space-sm;
+
+    @include xs {
+      width: 272px;
+    }
 
     @include sm {
       width: 360px;

--- a/profiles/static/scss/components/_nav.scss
+++ b/profiles/static/scss/components/_nav.scss
@@ -6,7 +6,6 @@ nav {
 
     li {
       display: inline-block;
-      margin-right: $space-md;
 
       a {
         display: inline-block;
@@ -16,8 +15,22 @@ nav {
 }
 
 .nav--header {
-  li:last-of-type {
-    margin-right: 0;
+  font-size: 0.8em;
+
+  @include sm {
+    font-size: 0.9em;
+  }
+
+  ul {
+    text-align: right;
+  }
+
+  li {
+    margin-left: $space-md;
+
+    &:first-of-type {
+      margin-left: 0;
+    }
   }
 }
 

--- a/profiles/static/scss/components/forms/_error.scss
+++ b/profiles/static/scss/components/forms/_error.scss
@@ -16,7 +16,7 @@ main .errorlist {
 
 main form {
   .fieldWrapper--container--has-error,
-  .fieldWrapper--has-error {
+  :not(.fieldWrapper--container--has-error) .fieldWrapper--has-error {
     padding-left: $space-md;
     border-left: 5px solid $color-red;
   }


### PR DESCRIPTION
### Don't double red line forms
When we have a "form error" (like "email and password do not belong to a user"), we give the whole form a red border.
Whereas when we have an error with one specific field ("email must be less than 200 words"), we give that field a red border.

When we had both, the borders would stack. Now they don't.

### Stack header nav links on mobile
Our site looks pretty good on mobile except for the top nav, with a broken layout that's one of the first things you see.

This CSS isn't meant to be the final design or anything, but it improves our top nav layout on mobile until such time as we want to solve this some other way.

## Screenshot 

| before | after |
|--------|-------|
|  double red border beside password field   |  one red border for the form    |
|  <img width="1493" alt="Screen Shot 2020-06-29 at 9 28 57 AM" src="https://user-images.githubusercontent.com/2454380/86012558-1b51fd80-b9ec-11ea-883b-34e791a765cc.png">  | <img width="1493" alt="Screen Shot 2020-06-29 at 9 29 00 AM" src="https://user-images.githubusercontent.com/2454380/86012573-1f7e1b00-b9ec-11ea-87f4-e54193ec8823.png">   |

| before | after |
|--------|-------|
|  "fr" and "login" nav links break the layout and aren't aligned with anything      |  "fr" and "login" nav links right aligned underneath the flag     |
| <img width="612" alt="Screen Shot 2020-06-29 at 9 30 35 AM" src="https://user-images.githubusercontent.com/2454380/86012569-1e4cee00-b9ec-11ea-819b-55de7d74869f.png">  | <img width="612" alt="Screen Shot 2020-06-29 at 9 30 33 AM" src="https://user-images.githubusercontent.com/2454380/86012571-1ee58480-b9ec-11ea-819c-e61d8268f60a.png">  |



