### PR TITLE
Add robots.txt disallowing indexing

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -1,8 +1,14 @@
 from django.contrib import admin
 from django.urls import path, include, re_path
+from django.http import HttpResponse
 from django.conf.urls.i18n import i18n_patterns
 
 urlpatterns = [
+    re_path(
+        r"^robots.txt",
+        lambda x: HttpResponse("User-Agent: *\nDisallow: /", content_type="text/plain"),
+        name="robots_file",
+    ),
     path("admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
 ]


### PR DESCRIPTION
Because Django serves static files from the "/static" directory, putting a file in there would end up as "/static/robots.txt", which isn't want we want. (It needs to be served from the root.)

These rules disallow us from being indexed, which is what we want as we don't want our site to be google-able.

Source:
- https://www.robotstxt.org/robotstxt.html
- https://adamj.eu/tech/2020/02/10/robots-txt/