### PR TITLE
lock healthcare administrators out of /admin/

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -77,5 +77,5 @@ class HealthcareUser(AbstractBaseUser):
     @property
     def is_staff(self):
         """Is the user a member of staff?"""
-        # Simplest possible answer: All admins are staff
-        return self.is_admin
+        # We only want superusers to have access to /admin
+        return self.is_superuser


### PR DESCRIPTION
We will be giving the is_admin property to healthcare administrators and using is_superuser for CDS folks.