### PR TITLE
Only superusers should be able to see the admin panel + allow superusers to create other superusers

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -30,7 +30,15 @@ class UserChangeForm(forms.ModelForm):
 
     class Meta:
         model = HealthcareUser
-        fields = ("email", "password", "name", "province", "is_active", "is_admin")
+        fields = (
+            "email",
+            "password",
+            "name",
+            "province",
+            "is_active",
+            "is_admin",
+            "is_superuser",
+        )
 
     def clean_password(self):
         # Regardless of what the user provides, return the initial value.
@@ -45,7 +53,7 @@ class UserAddForm(UserCreationForm):
 
     class Meta:
         model = HealthcareUser
-        fields = ("email", "name", "province", "is_admin")
+        fields = ("email", "name", "province", "is_admin", "is_superuser")
 
     def clean_email(self):
         email = self.cleaned_data.get("email", "").lower()
@@ -60,12 +68,13 @@ class UserAdmin(BaseUserAdmin):
     # The fields to be used in displaying the User model.
     # These override the definitions on the base UserAdmin
     # that reference specific fields on auth.User.
-    list_display = ("email", "name", "province", "is_admin")
-    list_filter = ("is_admin",)
+    list_display = ("email", "name", "province", "is_admin", "is_superuser")
+    list_filter = ("is_admin", "is_superuser")
 
     fieldsets = (
-        (None, {"fields": ("email", "password", "is_admin")}),
+        (None, {"fields": ("email", "password")}),
         ("Personal info", {"fields": ("name", "province")}),
+        ("Permissions", {"fields": ("is_admin", "is_superuser")}),
     )
 
     # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin
@@ -75,16 +84,10 @@ class UserAdmin(BaseUserAdmin):
             None,
             {
                 "classes": ("wide",),
-                "fields": (
-                    "email",
-                    "name",
-                    "province",
-                    "is_admin",
-                    "password1",
-                    "password2",
-                ),
+                "fields": ("email", "name", "province", "password1", "password2",),
             },
         ),
+        ("Permissions", {"fields": ("is_admin", "is_superuser")}),
     )
     search_fields = ("email",)
     ordering = ("email",)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -77,5 +77,5 @@ class HealthcareUser(AbstractBaseUser):
     @property
     def is_staff(self):
         """Is the user a member of staff?"""
-        # Simplest possible answer: All admins are staff
-        return self.is_admin
+        # Only superusers can use the django backend
+        return self.is_superuser

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -15,18 +15,25 @@ class HealthcareProvince(models.Model):
 
 
 class HealthcareUserManager(BaseUserManager):
-    def create_user(self, email, name, province, is_admin=False, password=None):
+    def create_user(
+        self, email, name, province, is_admin=False, is_superuser=False, password=None
+    ):
         """
         Creates and saves a User with the given email and password
         """
         if not email:
             raise ValueError("Users must have an email address")
 
+        # force is_admin to True when creating a superuser
+        if is_superuser:
+            is_admin = True
+
         user = self.model(
             email=self.normalize_email(email),
             name=name,
             province=province,
             is_admin=is_admin,
+            is_superuser=is_superuser,
         )
 
         user.set_password(password)
@@ -38,9 +45,9 @@ class HealthcareUserManager(BaseUserManager):
         Creates and saves a superuser with the given email, name and password.
         """
         ontario = HealthcareProvince.objects.get(abbr="ON")
-        user = self.create_user(email, name=name, province=ontario, password=password)
-        user.is_admin = True
-        user.is_superuser = True
+        user = self.create_user(
+            email, name=name, province=ontario, password=password, is_superuser=True
+        )
         user.save(using=self._db)
         return user
 


### PR DESCRIPTION
This PR does a couple things:

- Only superusers will be allowed to view the admin panel (+ tests)
- Adds "is_superuser" property to the user creation + user editing form in the django backend. This means that superusers will be able to create other superusers (previously this was only possible on the command line).
  - I'm also grouping the fields differently so that the permissions fields are at the bottom under the "Permissions" heading.

## Screenshots

| description | screens  |
|---|---|
| see superusers in the user list on the admin panel  | <img width="1424" alt="Screen Shot 2020-07-07 at 6 12 38 PM" src="https://user-images.githubusercontent.com/2454380/86849749-21944980-c07e-11ea-9ec6-0f259e2a733d.png">  |
| `is_superuser` checkbox when creating a new user (at the bottom)   |  <img width="1424" alt="Screen Shot 2020-07-07 at 6 11 48 PM" src="https://user-images.githubusercontent.com/2454380/86849760-2527d080-c07e-11ea-9652-23c93574bd51.png">  |
| `is_superuser` checkbox when editing an existing user  |   <img width="1424" alt="Screen Shot 2020-07-07 at 6 12 31 PM" src="https://user-images.githubusercontent.com/2454380/86849757-235e0d00-c07e-11ea-9818-ab2e49d15322.png"> |

