### PR TITLE
Nginx config for proper scheme traversal of proxy

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -8,10 +8,12 @@
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
+        proxy_redirect off;
         proxy_http_version    1.1;
         proxy_set_header    Host                $new_host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $new_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $new_host;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
     }
  
 


### PR DESCRIPTION
This config is needed so that Django can be advised that there is HTTPS upstream in production zone where it checks to ensure SSL on connections.  The Application Load balancer is setting the X-Forwarded-Proto header but the current nginx config wasn't passing it along. 