### PR TITLE
Remove Nginx Proxy redirect config

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -8,10 +8,12 @@
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
+        proxy_redirect off;
         proxy_http_version    1.1;
         proxy_set_header    Host                $new_host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $new_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $new_host;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
     }
  
 

--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -8,7 +8,6 @@
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
-        proxy_redirect off;
         proxy_http_version    1.1;
         proxy_set_header    Host                $new_host;
         proxy_set_header    X-Real-IP           $remote_addr;


### PR DESCRIPTION
Django isn't setup to handle proxy redirects on it's own.  Need to allow Nginx to handle them for Django - basically the default setting.