### PR TITLE
Last change to Nginx Config

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -5,6 +5,10 @@
         set $new_host "ELB-HealthChecker.elasticbeanstalk.com";
     }
 
+    if ($http_x_forwarded_proto = 'http'){
+    return 301 https://$host$request_uri;
+    }
+
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
@@ -12,7 +16,6 @@
         proxy_set_header    Host                $new_host;
         proxy_set_header    X-Real-IP           $remote_addr;
         proxy_set_header    X-Forwarded-For     $new_host;
-        proxy_set_header    X-Forwarded-Proto   $scheme;
     }
  
 

--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -8,10 +8,12 @@
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
+        proxy_redirect off;
         proxy_http_version    1.1;
         proxy_set_header    Host                $new_host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $new_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $new_host;
+        proxy_set_header    X-Forwarded-Proto   $scheme;
     }
  
 

--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -8,7 +8,6 @@
     location / {
 
         proxy_pass            http://127.0.0.1:8000;
-        proxy_redirect off;
         proxy_http_version    1.1;
         proxy_set_header    Host                $new_host;
         proxy_set_header    X-Real-IP           $remote_addr;


### PR DESCRIPTION
Removal of previous fix due to too many redirects happening.
Instead catching to see if upstream is http and if so get Nginx to send back redirect instead of Load Balancer or Django.
Tested in AWS (this branch is running live on AWS Prod right now) so this will be the last Nginx config change.