### PR TITLE
Limit SESSION_COOKIE_AGE to 20 hours

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -156,6 +156,9 @@ SESSION_COOKIE_SECURE = is_prod
 CSRF_COOKIE_SECURE = is_prod
 SECURE_BROWSER_XSS_FILTER = is_prod
 
+# Limit session times to 20h, this should make it that users need to relogin every morning.
+SESSION_COOKIE_AGE = 72000
+
 # Setting SECURE_SSL_REDIRECT on heroku was causing infinite redirects without this
 if is_prod:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
Related to SR-4 Security we'll start by limiting the session to 20h. This should mean that folks only need to login once a day, probably in their morning.

If user research demonstrates that this is too burdensome we can revisit it later.