### PR TITLE
Modify default SU email and Heroku Config

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -6,4 +6,5 @@ run:
     python manage.py sass profiles/static/scss/styles.scss profiles/static/css/
     python manage.py collectstatic --noinput -i scss
     python manage.py migrate
+    python manage.py createdefaultsuperuser
     gunicorn portal.wsgi --log-file -

--- a/profiles/management/commands/createdefaultsuperuser.py
+++ b/profiles/management/commands/createdefaultsuperuser.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if SU_EXISTS:
             self.stdout.write(self.style.SUCCESS("Default Super User already exists"))
-        elif CREATE_DEFAULT_SU and SU_DEFAULT_PASSWORD and not SU_EXISTS:
+        elif CREATE_DEFAULT_SU and SU_DEFAULT_PASSWORD:
             self.create_su()
         else:
             self.stdout.write(self.style.SUCCESS("Not creating default Super User"))
@@ -22,6 +22,6 @@ class Command(BaseCommand):
         # https://docs.djangoproject.com/en/3.0/topics/auth/passwords/#django.contrib.auth.password_validation.validate_password
         if validate_password(SU_DEFAULT_PASSWORD) is None:
             HealthcareUser.objects.create_superuser(
-                "hcw_portal_admin@cds-snc.ca", "hcw_portal_admin", SU_DEFAULT_PASSWORD
+                "admin@cds-snc.ca", "hcw_portal_admin", SU_DEFAULT_PASSWORD
             )
             self.stdout.write(self.style.SUCCESS("Successfully created new super user"))


### PR DESCRIPTION
- Heroku config will now create the default super user during PR deployments
- Default SU admin email changed to admin@cds-snc.ca
- Refactored `createdefaultsuperuser` logic to remove duplicate logic check as per @pcraig3 suggestion.