### PR TITLE
Always show current user first in list of users

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
+from django.db.models.expressions import RawSQL
 
 from invitations.models import Invitation
 
@@ -89,9 +90,11 @@ class InviteCompleteView(LoginRequiredMixin, IsAdminMixin, TemplateView):
 
 class ProfilesView(LoginRequiredMixin, IsAdminMixin, ListView):
     def get_queryset(self):
-        return HealthcareUser.objects.filter(
-            province=self.request.user.province
-        ).order_by("-is_admin")
+        return (
+            HealthcareUser.objects.filter(province=self.request.user.province)
+            .annotate(current_user_id=RawSQL("id = %s", (self.request.user.id,)))
+            .order_by("-current_user_id", "-is_admin")
+        )
 
 
 class ProvinceAdminManageMixin(UserPassesTestMixin):


### PR DESCRIPTION
This PR orders the list of users such that the current user is always at the top of the list.

I was looking at the docs for `order_by` but there's no easy way to add a custom parameter into the order_by clause without using RawSQL, although we are sanitizing the parameter we pass in.

Sources:
- Adding an id using RawSQL: https://www.reddit.com/r/django/comments/6x9j5h/custom_order_by_parameter/
- `order_by` docs: https://docs.djangoproject.com/en/3.0/ref/models/querysets/#order-by
- `RawSQL` docs: https://docs.djangoproject.com/en/3.0/ref/models/expressions/#raw-sql-expressions