### PR TITLE
[hotfix] Add missing i18n tag to the password reset page template

### DIFF
--- a/profiles/templates/profiles/start.html
+++ b/profiles/templates/profiles/start.html
@@ -10,7 +10,7 @@
   </p>
   <ul>
     <li>{% trans "tested positive for COVID-19" %}</li>
-    <li>{% trans "the app installed on Andriod or Apple mobile device" %}</li>
+    <li>{% trans "the app installed on Android or Apple mobile device" %}</li>
   </ul>
   <p>
     {% trans "Tell the patient the number will expire within 24 hours." %}

--- a/profiles/templates/registration/password_reset_done.html
+++ b/profiles/templates/registration/password_reset_done.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
 {% block title %}{% trans "Check your email" %}{% endblock %}
 


### PR DESCRIPTION
Looks like we missed this earlier.

Causes a template error right now when you try to load the page.