### PR TITLE
HotFix - Add Allowed_Hosts to content security policy

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -244,3 +244,8 @@ CSP_DEFAULT_SRC = ["'self'"]
 CSP_STYLE_SRC = ["'self'", "fonts.googleapis.com"]
 CSP_FONT_SRC = ["'self'", "fonts.gstatic.com"]
 CSP_SCRIPT_SRC = ["'self'", "cdnjs.cloudflare.com"]
+if os.getenv("ALLOWED_HOSTS"):
+    CSP_DEFAULT_SRC.extend(os.getenv("ALLOWED_HOSTS").split(","))
+    CSP_STYLE_SRC.extend(os.getenv("ALLOWED_HOSTS").split(","))
+    CSP_FONT_SRC.extend(os.getenv("ALLOWED_HOSTS").split(","))
+    CSP_SCRIPT_SRC.extend(os.getenv("ALLOWED_HOSTS").split(","))


### PR DESCRIPTION
Some scripts not running in staging and prod due to new security headers.  Adding any host value added to Allowed_Hosts to CSP headers as well.  The 'self' flag was not detecting that the script was local to itself because of the DNS termination upstream on the load balancer.