### PR TITLE
Use <time> element for Expires timestamp

### DIFF
--- a/profiles/static/js/time_formatting.js
+++ b/profiles/static/js/time_formatting.js
@@ -1,13 +1,13 @@
-document.addEventListener('DOMContentLoaded', function(){
-  const expiry = moment().add(1, 'days');
-  const lang = JSON.parse(document.getElementById('lang_code').textContent);
-  if (lang == 'fr') {
-      // example : 12 juillet a 18 h 12, heure locale
-      document.getElementById('expiry-date').innerHTML = expiry.format('D MMMM');
-      document.getElementById('expiry-time').innerHTML = expiry.format('HH [h] mm')+ ', heure locale';
+document.addEventListener("DOMContentLoaded", function () {
+  var expiry = moment().add(1, "days");
+  var lang = JSON.parse(document.getElementById("lang_code").textContent);
+
+  if (lang == "fr") {
+    // example : 12 juillet a 18 h 12, heure locale
+    document.getElementById("expiry-datetime").innerHTML = expiry.format("D MMMM") + " à " + expiry.format("HH [h] mm") + ", heure locale";
   } else {
-      // example : July 12 at 6:12 pm local time
-      document.getElementById('expiry-date').innerHTML = expiry.format('MMMM D');
-      document.getElementById('expiry-time').innerHTML = expiry.format('h:mm a') + ' local time';
+    // example : July 12 at 6:12 pm local time
+    document.getElementById("expiry-datetime").innerHTML = expiry.format("MMMM D") + " at " + expiry.format("h:mm a") + " local time";
   }
 }, false);
+

--- a/profiles/templates/includes/expires_string.html
+++ b/profiles/templates/includes/expires_string.html
@@ -4,21 +4,22 @@
 {% get_current_language as LANGUAGE_CODE %}
 
 {% timezone "Canada/Eastern" %}
-<span>{% trans "Number expires" %}</span>
-  <span id="expiry-date">
-    {% if LANGUAGE_CODE == 'en' %}
-        {{ expiry|date:"F j" }}
-    {% else %}
-        {{ expiry|date:"j F" }}
-    {% endif %}
-  </span>
-  <span>{% trans "at" %}</span>
-  <span id="expiry-time">
-    {% if LANGUAGE_CODE == 'en' %}
-        {{ expiry|date:"f a e" }}
-    {% else %}
-        {{ expiry|date:"G \h i e" }}
-    {% endif %}
+  <span>{% trans "Number expires" %}
+    <time id="expiry-datetime" datetime="{{ expiry|date:'c' }}">
+      {% if LANGUAGE_CODE == 'en' %}
+          {{ expiry|date:"F j" }}
+      {% else %}
+          {{ expiry|date:"j F" }}
+      {% endif %}
+
+      {% trans "at" %}
+
+      {% if LANGUAGE_CODE == 'en' %}
+          {{ expiry|date:"f a e" }}
+      {% else %}
+          {{ expiry|date:"G \h i e" }}
+      {% endif %}
+    </time>
   </span>
 {% endtimezone %}
 
@@ -26,4 +27,3 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/locale/{{ LANGUAGE_CODE }}-ca.min.js"></script>
 {{ LANGUAGE_CODE|json_script:"lang_code" }}
 <script src="{% static 'js/time_formatting.js' %}"></script>
-


### PR DESCRIPTION
It's easier for screen readers to read out this way.

Source:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time

## Screenshot

| before | after |
|----|----|
| the expiry time is broken into ~5 spans  |  expiry time is grouped into one `<time>` element (wrapped in a span)   |
| <img width="973" alt="Screen Shot 2020-07-14 at 5 53 02 PM" src="https://user-images.githubusercontent.com/2454380/87480306-09cb4100-c5fb-11ea-8e85-b868204ea75f.png">  | <img width="973" alt="Screen Shot 2020-07-14 at 5 52 23 PM" src="https://user-images.githubusercontent.com/2454380/87480311-0d5ec800-c5fb-11ea-8d21-7d22050a0895.png">  |

