### PR TITLE
Set sticky footer using flexbox

### DIFF
--- a/profiles/static/scss/_base.scss
+++ b/profiles/static/scss/_base.scss
@@ -118,6 +118,17 @@ li:not(:last-of-type) {
 .container {
   position: relative;
   min-height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+
+  main {
+    flex: 1 0 auto;
+  }
+
+  footer {
+    flex-shrink: 0;
+  }
 }
 
 .page--container {


### PR DESCRIPTION
Spent a much longer time than I needed to futzing around with fixed heights and negative margins and all that stuff. 
Eventually realized I could use flexbox, and that was all she wrote.

Way easier than it used to be. The container is always 100% height, so we need to make sure the footer is stuck to the end of it.

## Screenshots

| before | after |
|----|----|
| <img width="1480" alt="Screen Shot 2020-07-16 at 9 53 38 AM" src="https://user-images.githubusercontent.com/2454380/87679677-77d24e00-c74a-11ea-9e74-f75c92e84e52.png">  | <img width="1480" alt="Screen Shot 2020-07-16 at 9 56 02 AM" src="https://user-images.githubusercontent.com/2454380/87679786-989aa380-c74a-11ea-9f24-f5b387417bbc.png">  |

